### PR TITLE
Optionally harden symlink accesses.

### DIFF
--- a/README
+++ b/README
@@ -127,6 +127,7 @@ lsmod		- denies non-root users from viewing loaded kernel modules
 proc_kallsyms	- denies non-root users from viewing /proc/kallsyms
 ps		- denies non-root users from viewing processes they don't own
 ps_gid		- gid of users who aren't restricted by ps. default 0 (off)
+restrict_setuid - denies non-root users the ability to use setuid() entirely
 harden_symlink	- denies non-root users from following symlinks to files owned
 		  by a different user (like grsecurity's GRKERNSEC_SYMLINKOWN)
 harden_hardlinks - denies non-root users from creating hardlinks to files owned

--- a/module.h
+++ b/module.h
@@ -111,5 +111,6 @@ extern int tpe_ps;
 extern int tpe_ps_gid;
 extern int tpe_harden_symlink;
 extern int tpe_harden_hardlinks;
+extern int tpe_restrict_setuid;
 
 #endif

--- a/sysctl.c
+++ b/sysctl.c
@@ -22,6 +22,7 @@ int tpe_ps = 0;
 int tpe_ps_gid = 0;
 int tpe_harden_symlink = 0;
 int tpe_harden_hardlinks = 0;
+int tpe_restrict_setuid = 0;
 
 static ctl_table tpe_extras_table[] = {
 	{
@@ -80,6 +81,16 @@ static ctl_table tpe_extras_table[] = {
 #endif
 		.procname	= "harden_hardlinks",
 		.data		= &tpe_harden_hardlinks,
+		.maxlen		= sizeof(int),
+		.mode		= 0644,
+		.proc_handler	= &proc_dointvec,
+	},
+	{
+#if LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 33)
+		.ctl_name	= CTL_UNNUMBERED,
+#endif
+		.procname	= "restrict_setuid",
+		.data		= &tpe_restrict_setuid,
 		.maxlen		= sizeof(int),
 		.mode		= 0644,
 		.proc_handler	= &proc_dointvec,


### PR DESCRIPTION
Based conceptually on grsecurity's GRKERNSEC_SYMLINKOWN feature, we hook into
following the symlinks.  Unlike grsecurity's solution, the method we use is
uglier due to the requirements of being a loadable module.

We hook the security_inode_follow_link() function and then follow the symlink.
This means we resolve the symlink twice per VFS operation, but the performance
hit does not seem to be too bad.

Signed-off-by: William Pitcock nenolod@dereferenced.org
