### PR TITLE
security.c: fix missing semicolon.

### DIFF
--- a/security.c
+++ b/security.c
@@ -275,7 +275,7 @@ static inline void tpe_release_nameidata(struct nameidata *dst) {
 		return;
 
 	if (dst->dentry)
-		dput(dst->dentry)
+		dput(dst->dentry);
 
 	if (dst->mnt)
 		mntput(dst->mnt);


### PR DESCRIPTION
Signed-off-by: Philip J Perry phil@elrepo.org
