### PR TITLE
whitelist two more programs

### DIFF
--- a/conf/tpe-mmap-whitelist
+++ b/conf/tpe-mmap-whitelist
@@ -1,5 +1,6 @@
 /usr/bin/cheese
 /usr/bin/empathy-accounts
+/usr/bin/gedit
 /usr/bin/gjs-console
 /usr/bin/gnome-contacts
 /usr/bin/gnome-control-center
@@ -7,6 +8,7 @@
 /usr/bin/gnome-shell
 /usr/bin/ibus-daemon
 /usr/bin/knotify4
+/usr/bin/seahorse
 /usr/bin/totem
 /usr/bin/virt-manager
 /usr/bin/yelp


### PR DESCRIPTION
Whitelisting two more programs, gedit and seahorse.

Apr 14 16:47:46 quad kernel: tpe: Denied untrusted mmap of
/tmp/ffivjP7ew (deleted) (uid:1000) by /usr/bin/gedit (uid:1000),
parents: /usr/lib/systemd/systemd (uid:0). Deny reason: directory is
writable

Apr 18 22:33:35 quad kernel: tpe: Denied untrusted mmap of
/tmp/ffiwHHase (deleted) (uid:1000) by /usr/bin/seahorse (uid:1000),
parents: /usr/lib/systemd/systemd (uid:0). Deny reason: directory is
writable

Signed-off-by: Philip J Perry <phil@elrepo.org>